### PR TITLE
Revert "Modal docs size variation card overflow"

### DIFF
--- a/resources/views/components/preview.blade.php
+++ b/resources/views/components/preview.blade.php
@@ -12,7 +12,7 @@
 @php($anchor ??= str($title)->slug()->lower())
 
 <div x-data="{ anchor : false }" @if ($id) id="{{ $id }}" @endif>
-    <div x-show="!code" @class(['rounded-lg p-6', 'bg-white shadow-md dark:bg-slate-800 overflow-auto custom-scrollbar' => $background])>
+    <div x-show="!code" @class(['rounded-lg p-6', 'bg-white shadow-md dark:bg-slate-800' => $background])>
         {{ $slot }}
     </div>
     @if ($contents)


### PR DESCRIPTION
Reverts #9 because generates a bug in some sections:

![CleanShot 2023-12-01 at 22 41 42](https://github.com/tallstackui/website/assets/60591772/24289155-8297-4824-b6d8-e7e9a93b4e7e)
