### PR TITLE
Fix v3 documentation code snippets to match live previews

### DIFF
--- a/app/Enums/Examples/V3/Alpine.php
+++ b/app/Enums/Examples/V3/Alpine.php
@@ -37,7 +37,7 @@ class Alpine
     <x-input label="Credit Card"
              hint="Insert your credit card number"
              x-mask:dynamic="creditCardMask" {{-- [tl! highlight] --}}
-             value="200.000" />
+             value="4444555566667777" />
 
     <script>
     function creditCardMask(input) {

--- a/app/Enums/Examples/V3/Form/Currency.php
+++ b/app/Enums/Examples/V3/Form/Currency.php
@@ -9,7 +9,7 @@ class Currency
     HTML;
 
     public const string LABEL_HINT = <<<'HTML'
-    <x-currency label="Salady Expectation" hint="Between 5,000 and 10,000 USD" />
+    <x-currency label="Salary Expectation" hint="Between 5,000 and 10,000 USD" />
     HTML;
 
     public const string CLEARABLE = <<<'HTML'

--- a/app/Enums/Examples/V3/Form/Number.php
+++ b/app/Enums/Examples/V3/Form/Number.php
@@ -21,7 +21,7 @@ class Number
     HTML;
 
     public const string MIN_MAX = <<<'HTML'
-    <x-number min="2" max="5" />
+    <x-number label="Quantity" hint="Press the plus button to increase one by one" min="1" max="10" />
     HTML;
 
     public const string CENTRALIZED = <<<'HTML'

--- a/app/Enums/Examples/V3/Form/Password.php
+++ b/app/Enums/Examples/V3/Form/Password.php
@@ -5,7 +5,7 @@ namespace App\Enums\Examples\V3\Form;
 class Password
 {
     public const string BASIC = <<<'HTML'
-    <x-password value="TallStackUi" />
+    <x-password value="TallStackUI" />
     HTML;
 
     public const string LABEL_HINT = <<<'HTML'

--- a/app/Enums/Examples/V3/Ui/Avatar.php
+++ b/app/Enums/Examples/V3/Ui/Avatar.php
@@ -152,10 +152,10 @@ class Avatar
     HTML;
 
     public const string PRESENCE_POSITIONS = <<<'HTML'
-    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="top-left" />
-    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="top-right" />
-    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="bottom-left" />
-    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="bottom-right" />
+    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="right-top" />
+    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="right-bottom" />
+    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="left-top" />
+    <x-avatar image="https://i.pravatar.cc/300" presence presence-position="left-bottom" />
     HTML;
 
     public const string CUSTOMIZATION = <<<'HTML'

--- a/app/Enums/Examples/V3/Ui/Card.php
+++ b/app/Enums/Examples/V3/Ui/Card.php
@@ -82,7 +82,7 @@ class Card
     </x-card>
 
     <!-- Light Variation -->
-    <x-card header="TallStackUI" color="primary">
+    <x-card header="TallStackUI" color="primary" light>
         TallStackUI
     </x-card>
 

--- a/app/Enums/Examples/V3/Ui/Progress.php
+++ b/app/Enums/Examples/V3/Ui/Progress.php
@@ -185,11 +185,11 @@ class Progress
     HTML;
 
     public const string CIRCLE_FOOTER_SLOT = <<<'HTML'
-    <x-progress :percent="50">
+    <x-progress.circle :percent="50">
         <x-slot:footer>
             TallStackUI
         </x-slot:footer>
-    </x-progress>
+    </x-progress.circle>
     HTML;
 
     public const string CUSTOMIZATION = <<<'HTML'

--- a/app/Enums/Examples/V3/Ui/Tooltip.php
+++ b/app/Enums/Examples/V3/Ui/Tooltip.php
@@ -37,7 +37,7 @@ class Tooltip
     <x-tooltip text="Top" position="top" icon="exclamation-circle" />
     <x-tooltip text="Bottom" position="bottom" icon="exclamation-triangle" />
     <x-tooltip text="Left" position="left" icon="shield-exclamation" />
-    <x-tooltip text="Right" position="right" />
+    <x-tooltip text="Right" position="right" icon="shield-check" />
     HTML;
 
     public const string SIZES = <<<'HTML'


### PR DESCRIPTION
## Summary

Eight component examples in the v3 docs had drift between the rendered live preview and the code snippet shown under the copy button, so users copying the snippet could not reproduce what they saw above it. This PR aligns each snippet with its preview.

## Changes

- **Ui/Card** `COLOR` — add missing `light` attribute to the "Light Variation" card
- **Ui/Avatar** `PRESENCE_POSITIONS` — replace invalid `top-left`/`top-right`/`bottom-left`/`bottom-right` values with the valid `right-top`/`right-bottom`/`left-top`/`left-bottom` accepted by the component
- **Ui/Progress** `CIRCLE_FOOTER_SLOT` — use `<x-progress.circle>` instead of `<x-progress>` to match the previewed component
- **Ui/Tooltip** `ICONS` — add missing `icon="shield-check"` to the Right tooltip
- **Form/Currency** `LABEL_HINT` — fix typo "Salady" → "Salary"
- **Form/Number** `MIN_MAX` — restore label, hint and match the min/max values shown in the preview
- **Form/Password** `BASIC` — fix casing "TallStackUi" → "TallStackUI"
- **Alpine** `INPUT` — fix credit card value from "200.000" to a valid 16-digit card number so the custom mask demonstrates correctly

## Test plan

- [x] `./vendor/bin/pest --filter="V3"` passes
- [ ] Reviewer: spot-check a couple of the affected pages in the docs site and confirm the code block under the copy button now matches the preview above it